### PR TITLE
update dependencies for Python 3.9+

### DIFF
--- a/certbot_dns_nextlayer/dns_nextlayer.py
+++ b/certbot_dns_nextlayer/dns_nextlayer.py
@@ -60,7 +60,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
         if self.conf("method") == "intelligent":
             ext = tldextract.extract(domain)
-            zone = ".".join(ext[-2:])
+            zone = ".".join([ext.domain, ext.suffix])
             return {"domain": zone, "validation_name": validation_name}
         elif self.conf("method") == "remove-first":
             ext = domain.split(".")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 acme>=0.31.0
-certbot>=0.31.0
+certbot>=3.2.0
 setuptools
 zope.interface
 dns-lexicon
-tldextract>=3.1.0
+tldextract>=5.0.0


### PR DESCRIPTION
The updated dependencies made it necessary to refactor `zone` recognition (tldextract no longer supports slicing of ExtractResult object).

The min versions now are:
- tldextract >= 5.0.0
- certbot >= 3.2.0